### PR TITLE
Init store with correct tree structure and make it devtools-compatible

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,14 +1,16 @@
-import { createStore, applyMiddleware, combineReducers } from 'redux';
+import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
 import thunk from 'redux-thunk';
 // import reducers to combine
 import averageRatingReducer from './overview/reducers/averageRatingReducer.js'
-import fetchProductInfo from './overview/reducers/fetchProductInfoReducer.js'
+import fetchProductInfoReducer from './overview/reducers/fetchProductInfoReducer.js'
 
 const rootReducer = combineReducers({
   averageRatingReducer,
-  fetchProductInfo
+  fetchProductInfoReducer
 });
 
-const store = createStore(rootReducer, {prodId: 1}, applyMiddleware(thunk));
+const initialState = {averageRatingReducer, fetchProductInfoReducer: { prodId: 1 }}
+
+const store = createStore(rootReducer, initialState, compose(applyMiddleware(thunk), window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()));
 
 export default store;


### PR DESCRIPTION
Rename fetchProductInfoReducer.js import alias.

Make prodId a property of fetchProductInfoReducer in initial state to abide by tree structure established by the rootReducer.